### PR TITLE
Allow to pass posix signal to executable

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 fx_root=`dirname "$(readlink -f "$0")"`
 
-MONO_PATH=$fx_root/mono/ mono $fx_root/CitizenMP.Server.exe $*
+MONO_PATH=$fx_root/mono/ exec mono $fx_root/CitizenMP.Server.exe $*


### PR DESCRIPTION
By using exec, the bash process will be remove and mono will take the lead, then all posix posignal (SIGINT, SIGTERM, ...) should be correctly passed to the executable.

However i don't know if thoses signals are already handled in the server (like sending a disconnect command to the client), but it's a start.