### PR TITLE
Fixed raw templates being ignored when there is only one arg.

### DIFF
--- a/resources/[system]/chat/html/Message.js
+++ b/resources/[system]/chat/html/Message.js
@@ -7,6 +7,11 @@ Vue.component('message', {
     textEscaped() {
       let s = this.template ? this.template : this.templates[this.templateId];
 
+      if (this.template) {
+        //We disable templateId since we are using a direct raw template
+        this.templateId = -1;
+      }
+
       //This hack is required to preserve backwards compatability
       if (this.templateId == CONFIG.defaultTemplateId
           && this.args.length == 1) {


### PR DESCRIPTION
When there was just one arg and a raw template, the template got swaped out with `CONFIG.defaultAltTemplateId`