### PR TITLE
added /clear command to clear chat

### DIFF
--- a/resources/[system]/chat/cl_chat.lua
+++ b/resources/[system]/chat/cl_chat.lua
@@ -85,7 +85,7 @@ end)
 
 RegisterCommand('clear', function(source, args, rawCommand)
     TriggerEvent('chat:clear')
-end)
+end, false)
 
 RegisterNUICallback('chatResult', function(data, cb)
   chatInputActive = false

--- a/resources/[system]/chat/cl_chat.lua
+++ b/resources/[system]/chat/cl_chat.lua
@@ -83,6 +83,10 @@ AddEventHandler('chat:clear', function(name)
   })
 end)
 
+RegisterCommand('clear', function(source, args, rawCommand)
+    TriggerEvent('chat:clear')
+end)
+
 RegisterNUICallback('chatResult', function(data, cb)
   chatInputActive = false
   SetNuiFocus(false)


### PR DESCRIPTION
when a player types `/clear` in chat the chat will be cleared (only for them). if you type `clear` in the server console nothing will happen (no error messages either).