### PR TITLE
Allow resources to disable chat messages per client (PR #2)

### DIFF
--- a/resources/[system]/chat/cl_chat.lua
+++ b/resources/[system]/chat/cl_chat.lua
@@ -19,15 +19,19 @@ AddEventHandler('chatMessage', function(author, color, text)
   if author ~= "" then
     table.insert(args, 1, author)
   end
-  SendNUIMessage({
-    type = 'ON_MESSAGE',
-    message = {
-      color = color,
-      multiline = true,
-      args = args
-    }
-  })
+  TriggerEvent("chat:cancelChatMessage")
+  if (not WasEventCanceled()) then
+    SendNUIMessage({
+      type = 'ON_MESSAGE',
+      message = {
+        color = color,
+        multiline = true,
+        args = args
+      }
+    })
+   end
 end)
+
 
 AddEventHandler('__cfx_internal:serverPrint', function(msg)
   print(msg)
@@ -43,10 +47,13 @@ AddEventHandler('__cfx_internal:serverPrint', function(msg)
 end)
 
 AddEventHandler('chat:addMessage', function(message)
-  SendNUIMessage({
-    type = 'ON_MESSAGE',
-    message = message
-  })
+  TriggerEvent("chat:cancelChatMessage")
+  if not WasEventCanceled() then
+    SendNUIMessage({
+      type = 'ON_MESSAGE',
+      message = message
+    })
+  end
 end)
 
 AddEventHandler('chat:addSuggestion', function(name, help, params)


### PR DESCRIPTION
Made the requested changes from the previous PR:
It now triggers the `chat:cancelChatMessage` (client) event. If a resource cancels that event, the chat message will not appear for that client (thus sort of disabling the chat for that client).