### PR TITLE
Added new Event, 'chat:commandEntered'

### DIFF
--- a/resources/[system]/chat/cl_chat.lua
+++ b/resources/[system]/chat/cl_chat.lua
@@ -8,6 +8,7 @@ RegisterNetEvent('chat:addSuggestion')
 RegisterNetEvent('chat:addSuggestions')
 RegisterNetEvent('chat:removeSuggestion')
 RegisterNetEvent('chat:clear')
+RegisterNetEvent('chat:commandEntered')
 
 -- internal events
 RegisterNetEvent('__cfx_internal:serverPrint')
@@ -105,6 +106,8 @@ RegisterNUICallback('chatResult', function(data, cb)
 
     if data.message:sub(1, 1) == '/' then
       ExecuteCommand(data.message:sub(2))
+      TriggerEvent('chat:commandEntered', data.message)
+      TriggerServerEvent('chat:commandEntered', data.message)
     else
       TriggerServerEvent('_chat:messageEntered', GetPlayerName(id), { r, g, b }, data.message)
     end

--- a/resources/[system]/chat/cl_chat.lua
+++ b/resources/[system]/chat/cl_chat.lua
@@ -106,8 +106,8 @@ RegisterNUICallback('chatResult', function(data, cb)
 
     if data.message:sub(1, 1) == '/' then
       ExecuteCommand(data.message:sub(2))
-      TriggerEvent('chat:commandEntered', data.message)
-      TriggerServerEvent('chat:commandEntered', data.message)
+      TriggerEvent('chat:commandEntered', data.message:sub(2))
+      TriggerServerEvent('chat:commandEntered', data.message:sub(2))
     else
       TriggerServerEvent('_chat:messageEntered', GetPlayerName(id), { r, g, b }, data.message)
     end

--- a/resources/[system]/chat/sv_chat.lua
+++ b/resources/[system]/chat/sv_chat.lua
@@ -6,6 +6,7 @@ RegisterServerEvent('chat:removeSuggestion')
 RegisterServerEvent('_chat:messageEntered')
 RegisterServerEvent('chat:clear')
 RegisterServerEvent('__cfx_internal:commandFallback')
+RegisterServerEvent('chat:commandEntered')
 
 AddEventHandler('_chat:messageEntered', function(author, color, message)
     if not message or not author then


### PR DESCRIPTION
An Event handler can be used to listen for a specific command.

Example:

```
AddEventHandler('chat:commandEntered', function(message)
	local com = 'Whisper'
	local comlen = com:len()
	
	if (message:sub(1, comlen):lower() == com:lower()) and (message:sub(comlen + 1, comlen + 1) == ' ') then
		print(message:sub(comlen + 2))
	end
end)
```