### PR TITLE
Resource Monitoring Script in sessionmanager / server-side

### DIFF
--- a/resources/[system]/sessionmanager/__resource.lua
+++ b/resources/[system]/sessionmanager/__resource.lua
@@ -1,3 +1,8 @@
 resource_manifest_version '77731fab-63ca-442c-a67b-abc70f28dfa5'
 
-server_script 'server/host_lock.lua'
+server_scripts {
+  'server/host_lock.lua',
+  'shared/resource_monitor.lua'
+}
+
+server_export 'isResourceRunning'

--- a/resources/[system]/sessionmanager/shared/resource_monitor.lua
+++ b/resources/[system]/sessionmanager/shared/resource_monitor.lua
@@ -23,8 +23,5 @@ end)
 
 -- Export end users can use
 function isResourceRunning(resourceName)
-	if resources[resourceName] == nil then
-		return
-	end
 	return resources[resourceName]
 end

--- a/resources/[system]/sessionmanager/shared/resource_monitor.lua
+++ b/resources/[system]/sessionmanager/shared/resource_monitor.lua
@@ -1,0 +1,30 @@
+-- resources
+local resources = {}
+
+-- Get all resources first
+Citizen.CreateThread(function()
+	local numResources = GetNumResources()
+	for index = 0, numResources - 1 do
+		local resourceName = GetResourceByFindIndex(index)
+		if resources[resourceName] == nil then
+			resources[resourceName] = false
+		end
+	end
+end)
+
+-- If a resource starts or stops, add it to resources with true
+AddEventHandler('onResourceStart', function(resourceName) 
+	resources[resourceName] = true
+end)
+
+AddEventHandler('onResourceStop', function(resourceName) 
+	resources[resourceName] = false
+end)
+
+-- Export end users can use
+function isResourceRunning(resourceName)
+	if resources[resourceName] == nil then
+		return
+	end
+	return resources[resourceName]
+end


### PR DESCRIPTION
Added a short resource monitoring script to return which resource is running.

It uses a shared logic, but is only able to execute on the server-side, as on my test-run the client-side started the resources in inverse order.