### PR TITLE
sessionmanager: adds empty client script to enable client to server remote callbacks

### DIFF
--- a/resources/[system]/sessionmanager/__resource.lua
+++ b/resources/[system]/sessionmanager/__resource.lua
@@ -1,3 +1,4 @@
 resource_manifest_version '77731fab-63ca-442c-a67b-abc70f28dfa5'
 
 server_script 'server/host_lock.lua'
+client_script 'client/empty.lua'

--- a/resources/[system]/sessionmanager/client/empty.lua
+++ b/resources/[system]/sessionmanager/client/empty.lua
@@ -1,0 +1,3 @@
+--This empty file causes the scheduler.lua to load clientside
+--scheduler.lua when loaded inside the sessionmanager resource currently manages remote callbacks.
+--Without this, callbacks will only work server->client and not client->server.


### PR DESCRIPTION
This fixes the case where callbacks weren't working sent from the client to the server. For example

client.lua
```
TriggerServerEvent("callbackTest", function(val)
  Citizen.Trace(val) --would never get called
end)
```
server.lua
```
RegisterNetEvent('callbackTest')
AddEventHandler('callbackTest', function(cb)
  cb("test")
end)
```