### PR TITLE
fix names with color codes coloring the whole console output.

### DIFF
--- a/resources/[system]/chat/sv_chat.lua
+++ b/resources/[system]/chat/sv_chat.lua
@@ -18,7 +18,7 @@ AddEventHandler('_chat:messageEntered', function(author, color, message)
         TriggerClientEvent('chatMessage', -1, author,  { 255, 255, 255 }, message)
     end
 
-    print(author .. ': ' .. message)
+    print(author .. '^7: ' .. message .. '^7')
 end)
 
 AddEventHandler('__cfx_internal:commandFallback', function(command)

--- a/resources/[system]/hardcap/server.lua
+++ b/resources/[system]/hardcap/server.lua
@@ -20,7 +20,7 @@ end)
 AddEventHandler('playerConnecting', function(name, setReason)
   local cv = GetConvarInt('sv_maxclients', 32)
 
-  print('Connecting: ' .. name)
+  print('Connecting: ' .. name .. '^7')
 
   if playerCount >= cv then
     print('Full. :(')


### PR DESCRIPTION
this adds a reset color code at the end of each name that is printed in console by hardcap, making sure if they contain colorcodes within them, they won't color the whole console output.