### PR TITLE
Fix 'killervehseat' being nil in 'onPlayerKilled' event.

### DIFF
--- a/resources/[system]/baseevents/deathevents.lua
+++ b/resources/[system]/baseevents/deathevents.lua
@@ -71,3 +71,13 @@ function GetPlayerByEntityID(id)
 	end
 	return nil
 end
+
+function GetPedVehicleSeat(ped)
+    local vehicle = GetVehiclePedIsIn(ped, false)
+    for k = -1, GetVehicleMaxNumberOfPassengers(vehicle) - 1  do
+        if GetPedInVehicleSeat(vehicle, k) == ped then
+            return k
+        end
+    end
+    return -2
+end

--- a/resources/[system]/baseevents/deathevents.lua
+++ b/resources/[system]/baseevents/deathevents.lua
@@ -74,9 +74,9 @@ end
 
 function GetPedVehicleSeat(ped)
     local vehicle = GetVehiclePedIsIn(ped, false)
-    for k = -1, GetVehicleMaxNumberOfPassengers(vehicle) - 1  do
-        if GetPedInVehicleSeat(vehicle, k) == ped then
-            return k
+    for seat = -1, GetVehicleMaxNumberOfPassengers(vehicle) - 1  do
+        if GetPedInVehicleSeat(vehicle, seat) == ped then
+            return seat
         end
     end
     return -2


### PR DESCRIPTION
Returns the proper vehicle seat, or -2 if the player is somehow not in a vehicle seat.