### PR TITLE
[hardcap] Remove '^x' patterns from usernames in connect msg

### DIFF
--- a/resources/[system]/hardcap/server.lua
+++ b/resources/[system]/hardcap/server.lua
@@ -20,7 +20,7 @@ end)
 AddEventHandler('playerConnecting', function(name, setReason)
   local cv = GetConvarInt('sv_maxclients', 32)
 
-  print('Connecting: ' .. name)
+  print('Connecting: ' .. name:gsub('%^%d', ''))
 
   if playerCount >= cv then
     print('Full. :(')


### PR DESCRIPTION
This prevents the console output color to change because some silly kid joined with "^1[Admin] iiSuperCool" or whatever.
(for those wondering, %d = any digit character)