### PR TITLE
chat: fix help text and params in chat suggestions

### DIFF
--- a/resources/[system]/chat/html/App.js
+++ b/resources/[system]/chat/html/App.js
@@ -77,11 +77,16 @@ window.APP = {
       this.oldMessagesIndex = -1;
     },
     ON_SUGGESTION_ADD({ suggestion }) {
+      const duplicateSuggestion = this.backingSuggestions.find(a => a.name == suggestion.name);
+      if (duplicateSuggestion) {
+        if(suggestion.help || suggestion.params) {
+          duplicateSuggestion.help = suggestion.help || "";
+          duplicateSuggestion.params = suggestion.params || [];
+        }
+        return;
+      }
       if (!suggestion.params) {
         suggestion.params = []; //TODO Move somewhere else
-      }
-      if (this.backingSuggestions.find(a => a.name == suggestion.name)) {
-        return;
       }
       this.backingSuggestions.push(suggestion);
     },


### PR DESCRIPTION
Fixed help text and params not being added after using `chat:addSuggestion` by allowing a chat suggestion to be "updated" new information.

Previously all registered commands would have a suggestion added for them by _chat_ and when a resource wanted to add its own chat suggestion with help text or params, _chat_ would see that there is already chat suggestion for the given command and ignore the resource's version of the chat suggestion.