### PR TITLE
Implemented chat:removeTemplate trigger

### DIFF
--- a/resources/[system]/chat/cl_chat.lua
+++ b/resources/[system]/chat/cl_chat.lua
@@ -5,6 +5,7 @@ local chatLoaded = false
 
 RegisterNetEvent('chatMessage')
 RegisterNetEvent('chat:addTemplate')
+RegisterNetEvent('chat:removeTemplate')
 RegisterNetEvent('chat:addMessage')
 RegisterNetEvent('chat:addSuggestion')
 RegisterNetEvent('chat:addSuggestions')
@@ -85,6 +86,15 @@ AddEventHandler('chat:addTemplate', function(id, html)
     template = {
       id = id,
       html = html
+    }
+  })
+end)
+
+AddEventHandler('chat:removeTemplate', function(id)
+  SendNUIMessage({
+    type = 'ON_TEMPLATE_REMOVE',
+    template = {
+      id = id
     }
   })
 end)

--- a/resources/[system]/chat/html/App.js
+++ b/resources/[system]/chat/html/App.js
@@ -97,9 +97,16 @@ window.APP = {
     },
     ON_TEMPLATE_ADD({ template }) {
       if (this.templates[template.id]) {
-        this.warn(`Tried to add duplicate template '${template.id}'`)
+        this.warn(`Tried to add duplicate template '${template.id}'`);
       } else {
         this.templates[template.id] = template.html;
+      }
+    },
+    ON_TEMPLATE_REMOVE({ template }) {
+      if (this.templates[template.id]) {
+        this.templates[template.id] = null;
+      } else {
+        this.warn(`Tried to remove template '${template.id}' that doesn't exist`);
       }
     },
     ON_UPDATE_THEMES({ themes }) {

--- a/resources/[system]/chat/sv_chat.lua
+++ b/resources/[system]/chat/sv_chat.lua
@@ -1,5 +1,6 @@
 RegisterServerEvent('chat:init')
 RegisterServerEvent('chat:addTemplate')
+RegisterServerEvent('chat:removeTemplate')
 RegisterServerEvent('chat:addMessage')
 RegisterServerEvent('chat:addSuggestion')
 RegisterServerEvent('chat:removeSuggestion')


### PR DESCRIPTION
## Description

This proposed PR brought to you by Hawaii implements the trigger `chat:removeTemplate` to remove existing message templates.

## Why?

I'm working on a resource that utilizes the chat templates to add small images in the messages. Every time I restart my resource it attempts to register the template but the chat resource will warn that the template already exists.

I don't want the end-users to experience warnings in chat everytime I decide to restart my resource. With this PR templates can now be unregistered with an easy trigger.

## Example

```lua
TriggerEvent('chat:addTemplate', 'tweet', "bla")

AddEventHandler('onResourceStop', function(resource)
	if resource == GetCurrentResourceName() then
		TriggerEvent('chat:removeTemplate', 'tweet')
	end
end)
```