### PR TITLE
rconlog: deprecated 'rconCommand' event

### DIFF
--- a/resources/[system]/rconlog/rconlog_server.lua
+++ b/resources/[system]/rconlog/rconlog_server.lua
@@ -49,32 +49,30 @@ AddEventHandler('chatMessage', function(netID, name, message)
     RconLog({ msgType = 'chatMessage', netID = netID, name = name, message = message, guid = GetPlayerIdentifiers(netID)[1] })
 end)
 
-AddEventHandler('rconCommand', function(commandName, args)
-    if commandName == 'status' then
-        for netid, data in pairs(names) do
-            local guid = GetPlayerIdentifiers(netid)
+RegisterCommand('status', function(source, args, rawCommand) 
+    for netid, data in pairs(names) do
+        local guid = GetPlayerIdentifiers(netid)
 
-            if guid and guid[1] and data then
-                local ping = GetPlayerPing(netid)
+        if guid and guid[1] and data then
+            local ping = GetPlayerPing(netid)
 
-                RconPrint(netid .. ' ' .. guid[1] .. ' ' .. data.name .. ' ' .. GetPlayerEP(netid) .. ' ' .. ping .. "\n")
-            end
+            RconPrint(netid .. ' ' .. guid[1] .. ' ' .. data.name .. ' ' .. GetPlayerEP(netid) .. ' ' .. ping .. "\n")
         end
-
-        CancelEvent()
-    elseif commandName:lower() == 'clientkick' then
-        local playerId = table.remove(args, 1)
-        local msg = table.concat(args, ' ')
-
-        DropPlayer(playerId, msg)
-
-        CancelEvent()
-    elseif commandName:lower() == 'tempbanclient' then
-        local playerId = table.remove(args, 1)
-        local msg = table.concat(args, ' ')
-
-        TempBanPlayer(playerId, msg)
-
-        CancelEvent()
     end
-end)
+end, true)
+
+RegisterCommand('clientkick', function(source, args, rawCommand)
+    local playerId = tonumber(args[1])
+    local msg = #args >= 2 and table.concat(args, ' ', 2) or 'No reason was provided.'
+    if not playerId or not GetPlayerName(playerId) then return end
+
+    DropPlayer(playerId .. msg)    
+end, true)
+
+RegisterCommand('tempbanclient', function(source, args, rawCommand)
+    local playerId = tonumber(args[1])
+    local msg = #args >= 2 and table.concat(args, ' ', 2) or 'No reason was provided.'
+    if not playerId or not GetPlayerName(playerId) then return end
+
+    TempBanPlayer(playerId, msg)
+end, true)

--- a/resources/[system]/rconlog/rconlog_server.lua
+++ b/resources/[system]/rconlog/rconlog_server.lua
@@ -66,7 +66,7 @@ RegisterCommand('clientkick', function(source, args, rawCommand)
     local msg = #args >= 2 and table.concat(args, ' ', 2) or 'No reason was provided.'
     if not playerId or not GetPlayerName(playerId) then return end
 
-    DropPlayer(playerId .. msg)    
+    DropPlayer(playerId, msg)    
 end, true)
 
 RegisterCommand('tempbanclient', function(source, args, rawCommand)


### PR DESCRIPTION
Move away from the deprecated event and use the [`REGISTER_COMMAND`](https://runtime.fivem.net/doc/natives/#_0x5FA79B0F) native and apply the restricted bool.