### PR TITLE
Added typing checks / "Is Chatbox Open?"

### DIFF
--- a/resources/[gameplay]/chat/README.md
+++ b/resources/[gameplay]/chat/README.md
@@ -1,1 +1,9 @@
 # Chat
+
+### Exports:
+`IsTyping()`  
+Client-side export for checking if the chat box is open (player is typing).  
+
+### Events:
+`chat:opened` & `chat:closed`  
+Client-side events that report when the chatbox is opened or closed  

--- a/resources/[gameplay]/chat/README.md
+++ b/resources/[gameplay]/chat/README.md
@@ -5,5 +5,8 @@
 Client-side export for checking if the chat box is open (player is typing).  
 
 ### Events:
-`chat:opened` & `chat:closed`  
+`AddEventHandler('chat:opened', function()
+  print("The chatbox was opened!")
+end)`
+& `chat:closed`  
 Client-side events that report when the chatbox is opened or closed  

--- a/resources/[gameplay]/chat/cl_chat.lua
+++ b/resources/[gameplay]/chat/cl_chat.lua
@@ -113,7 +113,8 @@ RegisterNUICallback('chatResult', function(data, cb)
       TriggerServerEvent('_chat:messageEntered', GetPlayerName(id), { r, g, b }, data.message)
     end
   end
-
+  
+  TriggerEvent('chat:closed')
   cb('ok')
 end)
 
@@ -188,6 +189,10 @@ RegisterNUICallback('loaded', function(data, cb)
   cb('ok')
 end)
 
+function IsTyping()
+  return chatInputActive
+end
+
 Citizen.CreateThread(function()
   SetTextChatEnabled(false)
   SetNuiFocus(false)
@@ -203,6 +208,7 @@ Citizen.CreateThread(function()
         SendNUIMessage({
           type = 'ON_OPEN'
         })
+        TriggerEvent('chat:opened')
       end
     end
 

--- a/resources/[gameplay]/chat/fxmanifest.lua
+++ b/resources/[gameplay]/chat/fxmanifest.lua
@@ -24,6 +24,8 @@ files {
     'html/vendor/fonts/LatoBold.woff2',
     'html/vendor/fonts/LatoBold2.woff2',
   }
+  
+export 'IsTyping' -- Returns boolean of chat window status (True = Typing)
 
 fx_version 'adamant'
 games { 'rdr3', 'gta5' }


### PR DESCRIPTION
Added an export for checking if the chatbox is open / being used, as well as opened and closed events. The events can be used to receive when the chatbox is opened or closed, while the export can be used for scripts that aren't waiting for the chatbox, but rather need to know at the time of it's own execution. I've tested the new code on my own server, and have not experienced any issues with it.