### PR TITLE
fix playernames serverside memory leak

### DIFF
--- a/resources/[gameplay]/playernames/playernames_cl.lua
+++ b/resources/[gameplay]/playernames/playernames_cl.lua
@@ -46,9 +46,9 @@ function updatePlayerNames()
     local localCoords = GetEntityCoords(PlayerPedId())
 
     -- for each valid player index
-    for i = 0, 255 do
+    for _, i in ipairs(GetActivePlayers()) do
         -- if the player exists
-        if NetworkIsPlayerActive(i) and i ~= PlayerId() then
+        if i ~= PlayerId() then
             -- get their ped
             local ped = GetPlayerPed(i)
             local pedCoords = GetEntityCoords(ped)

--- a/resources/[gameplay]/playernames/playernames_sv.lua
+++ b/resources/[gameplay]/playernames/playernames_sv.lua
@@ -1,6 +1,8 @@
 local curTemplate
 local curTags = {}
 
+local activePlayers = {}
+
 local function detectUpdates()
     SetTimeout(500, detectUpdates)
 
@@ -14,23 +16,34 @@ local function detectUpdates()
 
     template = GetConvar('playerNames_svTemplate', '[{{id}}] {{name}}')
 
-    for _, v in ipairs(GetPlayers()) do
+    for v, _ in pairs(activePlayers) do
         local newTag = formatPlayerNameTag(v, template)
-
         if newTag ~= curTags[v] then
             setName(v, newTag)
 
             curTags[v] = newTag
         end
     end
+
+    for i, tag in pairs(curTags) do
+        if not activePlayers[i] then
+            curTags[i] = nil
+        end
+    end
 end
 
-
+Citizen.CreateThread(function()
+    AddEventHandler('playerDropped', function()
+        local src = source -- 🏎️
+        curTags[src] = nil
+        activePlayers[src] = nil
+    end)
+end)
 
 RegisterNetEvent('playernames:init')
 AddEventHandler('playernames:init', function()
     reconfigure(source)
+    activePlayers[source] = true
 end)
 
-SetTimeout(500, detectUpdates)
 detectUpdates()

--- a/resources/[gameplay]/playernames/playernames_sv.lua
+++ b/resources/[gameplay]/playernames/playernames_sv.lua
@@ -20,7 +20,7 @@ local function detectUpdates()
         local newTag = formatPlayerNameTag(v, template)
         if newTag ~= curTags[v] then
             setName(v, newTag)
-
+            
             curTags[v] = newTag
         end
     end
@@ -32,11 +32,9 @@ local function detectUpdates()
     end
 end
 
-Citizen.CreateThread(function()
-    AddEventHandler('playerDropped', function()
-        curTags[source] = nil
-        activePlayers[source] = nil
-    end)
+AddEventHandler('playerDropped', function()
+    curTags[source] = nil
+    activePlayers[source] = nil
 end)
 
 RegisterNetEvent('playernames:init')

--- a/resources/[gameplay]/playernames/playernames_sv.lua
+++ b/resources/[gameplay]/playernames/playernames_sv.lua
@@ -27,16 +27,15 @@ local function detectUpdates()
 
     for i, tag in pairs(curTags) do
         if not activePlayers[i] then
-            curTags[i] = nil
+            curTags[i] = nil -- in case curTags doesnt get cleared when the player left, clear it now.
         end
     end
 end
 
 Citizen.CreateThread(function()
     AddEventHandler('playerDropped', function()
-        local src = source -- 🏎️
-        curTags[src] = nil
-        activePlayers[src] = nil
+        curTags[source] = nil
+        activePlayers[source] = nil
     end)
 end)
 


### PR DESCRIPTION
Server Code never cleared the tags of people that left, so with every player that joined, that tag was never removed from memory, causing a memory leak, the detectUpdates function was also ran **twice** every 500ms.

Where is the gametype contest prize money, anyway?