### PR TITLE
updating baseevents & scoreboard

### DIFF
--- a/resources/[system]/baseevents/deathevents.lua
+++ b/resources/[system]/baseevents/deathevents.lua
@@ -1,73 +1,69 @@
 Citizen.CreateThread(function()
-    local isDead = false
-    local hasBeenDead = false
+  local isDead = false
+  local hasBeenDead = false
 	local diedAt
 
-    while true do
-        Wait(0)
+  while true do
+    Wait(0)
 
-        local player = PlayerId()
+    local player = PlayerId()
 
-        if NetworkIsPlayerActive(player) then
-            local ped = PlayerPedId()
+    if NetworkIsPlayerActive(player) then
+      local ped = PlayerPedId()
 
-            if IsPedFatallyInjured(ped) and not isDead then
-                isDead = true
-                if not diedAt then
-                	diedAt = GetGameTimer()
-                end
-
-                local killer, killerweapon = NetworkGetEntityKillerOfPlayer(player)
-				local killerentitytype = GetEntityType(killer)
-				local killertype = -1
-				local killerinvehicle = false
-				local killervehiclename = ''
-                local killervehicleseat = 0
-				if killerentitytype == 1 then
-					killertype = GetPedType(killer)
-					if IsPedInAnyVehicle(killer, false) == 1 then
-						killerinvehicle = true
-						killervehiclename = GetDisplayNameFromVehicleModel(GetEntityModel(GetVehiclePedIsUsing(killer)))
-                        killervehicleseat = GetPedVehicleSeat(killer)
-					else killerinvehicle = false
-					end
-				end
-
-				local killerid = GetPlayerByEntityID(killer)
-				if killer ~= ped and killerid ~= nil and NetworkIsPlayerActive(killerid) then killerid = GetPlayerServerId(killerid)
-				else killerid = -1
-				end
-
-                if killer == ped or killer == -1 then
-                    TriggerEvent('baseevents:onPlayerDied', killertype, { table.unpack(GetEntityCoords(ped)) })
-                    TriggerServerEvent('baseevents:onPlayerDied', killertype, { table.unpack(GetEntityCoords(ped)) })
-                    hasBeenDead = true
-                else
-                    TriggerEvent('baseevents:onPlayerKilled', killerid, {killertype=killertype, weaponhash = killerweapon, killerinveh=killerinvehicle, killervehseat=killervehicleseat, killervehname=killervehiclename, killerpos={table.unpack(GetEntityCoords(ped))}})
-                    TriggerServerEvent('baseevents:onPlayerKilled', killerid, {killertype=killertype, weaponhash = killerweapon, killerinveh=killerinvehicle, killervehseat=killervehicleseat, killervehname=killervehiclename, killerpos={table.unpack(GetEntityCoords(ped))}})
-                    hasBeenDead = true
-                end
-            elseif not IsPedFatallyInjured(ped) then
-                isDead = false
-                diedAt = nil
-            end
-
-            -- check if the player has to respawn in order to trigger an event
-            if not hasBeenDead and diedAt ~= nil and diedAt > 0 then
-                TriggerEvent('baseevents:onPlayerWasted', { table.unpack(GetEntityCoords(ped)) })
-                TriggerServerEvent('baseevents:onPlayerWasted', { table.unpack(GetEntityCoords(ped)) })
-
-                hasBeenDead = true
-            elseif hasBeenDead and diedAt ~= nil and diedAt <= 0 then
-                hasBeenDead = false
-            end
+      if IsPedFatallyInjured(ped) and not isDead then
+        isDead = true
+        if not diedAt then
+          diedAt = GetGameTimer()
         end
-    end
-end)
 
-function GetPlayerByEntityID(id)
-	for i=0,32 do
-		if(NetworkIsPlayerActive(i) and GetPlayerPed(i) == id) then return i end
-	end
-	return nil
-end
+        local killer, killerweapon = NetworkGetEntityKillerOfPlayer(player)
+        local killerentitytype = GetEntityType(killer)
+        local killertype = -1
+        local killerinvehicle = false
+        local killervehiclename = ''
+        local killervehicleseat = 0
+        if killerentitytype == 1 then
+          killertype = GetPedType(killer)
+          if IsPedInAnyVehicle(killer, false) == 1 then
+            killerinvehicle = true
+            killervehiclename = GetDisplayNameFromVehicleModel(GetEntityModel(GetVehiclePedIsUsing(killer)))
+            killervehicleseat = GetPedVehicleSeat(killer)
+          else
+            killerinvehicle = false
+          end
+        end
+
+        local killerid = NetworkGetPlayerIndexFromPed(killer)
+        if killer ~= ped and killerid ~= nil and NetworkIsPlayerActive(killerid) then
+          killerid = GetPlayerServerId(killerid)
+        else
+          killerid = -1
+        end
+
+        if killer == ped or killer == -1 then
+          TriggerEvent('baseevents:onPlayerDied', killertype, { table.unpack(GetEntityCoords(ped)) })
+          TriggerServerEvent('baseevents:onPlayerDied', killertype, { table.unpack(GetEntityCoords(ped)) })
+          hasBeenDead = true
+        else
+          TriggerEvent('baseevents:onPlayerKilled', killerid, {killertype=killertype, weaponhash = killerweapon, killerinveh=killerinvehicle, killervehseat=killervehicleseat, killervehname=killervehiclename, killerpos={table.unpack(GetEntityCoords(ped))}})
+          TriggerServerEvent('baseevents:onPlayerKilled', killerid, {killertype=killertype, weaponhash = killerweapon, killerinveh=killerinvehicle, killervehseat=killervehicleseat, killervehname=killervehiclename, killerpos={table.unpack(GetEntityCoords(ped))}})
+          hasBeenDead = true
+        end
+      elseif not IsPedFatallyInjured(ped) then
+        isDead = false
+        diedAt = nil
+      end
+
+      -- check if the player has to respawn in order to trigger an event
+      if not hasBeenDead and diedAt ~= nil and diedAt > 0 then
+        TriggerEvent('baseevents:onPlayerWasted', { table.unpack(GetEntityCoords(ped)) })
+        TriggerServerEvent('baseevents:onPlayerWasted', { table.unpack(GetEntityCoords(ped)) })
+
+        hasBeenDead = true
+      elseif hasBeenDead and diedAt ~= nil and diedAt <= 0 then
+        hasBeenDead = false
+      end
+    end
+  end
+end)

--- a/resources/[system]/baseevents/fxmanifest.lua
+++ b/resources/[system]/baseevents/fxmanifest.lua
@@ -1,3 +1,6 @@
 client_script 'deathevents.lua'
 client_script 'vehiclechecker.lua'
 server_script 'server.lua'
+
+fx_version 'adamant'
+games { 'gta5' }

--- a/resources/[system]/scoreboard/fxmanifest.lua
+++ b/resources/[system]/scoreboard/fxmanifest.lua
@@ -4,6 +4,7 @@ description 'Scoreboard'
 ui_page 'html/scoreboard.html'
 
 client_script 'scoreboard.lua'
+server_script 'scoreboard_sv.lua'
 
 files {
     'html/scoreboard.html',

--- a/resources/[system]/scoreboard/scoreboard.lua
+++ b/resources/[system]/scoreboard/scoreboard.lua
@@ -9,7 +9,7 @@ Citizen.CreateThread(function()
         if IsControlPressed(0, 27)--[[ INPUT_PHONE ]] then
             if not listOn then
                 local players = {}
-                for id, name in ipairs(PlayerList) do
+                for id, name in pairs(PlayerList) do
                   if name then
                     local playerid = GetPlayerFromServerId(id)
                     local wantedLevel = GetPlayerWantedLevel(playerid)

--- a/resources/[system]/scoreboard/scoreboard.lua
+++ b/resources/[system]/scoreboard/scoreboard.lua
@@ -1,4 +1,5 @@
 local listOn = false
+local PlayerList = {}
 
 Citizen.CreateThread(function()
     listOn = false
@@ -8,15 +9,17 @@ Citizen.CreateThread(function()
         if IsControlPressed(0, 27)--[[ INPUT_PHONE ]] then
             if not listOn then
                 local players = {}
-                local ptable = GetActivePlayers()
-                for _, i in ipairs(ptable) do
-                    local wantedLevel = GetPlayerWantedLevel(i)
-                    r, g, b = GetPlayerRgbColour(i)
-                    table.insert(players, 
-                    '<tr style=\"color: rgb(' .. r .. ', ' .. g .. ', ' .. b .. ')\"><td>' .. GetPlayerServerId(i) .. '</td><td>' .. sanitize(GetPlayerName(i)) .. '</td><td>' .. (wantedLevel and wantedLevel or tostring(0)) .. '</td></tr>'
+                for id, name in ipairs(PlayerList) do
+                  if name then
+                    local playerid = GetPlayerFromServerId(id)
+                    local wantedLevel = GetPlayerWantedLevel(playerid)
+                    r, g, b = GetPlayerRgbColour(playerid)
+                    table.insert(players,
+                    '<tr style=\"color: rgb(' .. r .. ', ' .. g .. ', ' .. b .. ')\"><td>' .. id .. '</td><td>' .. sanitize(name) .. '</td><td>' .. (wantedLevel and wantedLevel or tostring(0)) .. '</td></tr>'
                     )
+                  end
                 end
-                
+
                 SendNUIMessage({ text = table.concat(players) })
 
                 listOn = true
@@ -35,11 +38,26 @@ Citizen.CreateThread(function()
     end
 end)
 
+RegisterNetEvent("Scoreboard:GetPlayerList")
+AddEventHandler("Scoreboard:GetPlayerList", function(list)
+  PlayerList = list
+end)
+
+Citizen.CreateThread(function()
+	while true do
+		Wait(0)
+		if NetworkIsSessionStarted() then
+			TriggerServerEvent('Scoreboard:ClientInitialized')
+			return
+		end
+	end
+end)
+
 function sanitize(txt)
     local replacements = {
-        ['&' ] = '&amp;', 
-        ['<' ] = '&lt;', 
-        ['>' ] = '&gt;', 
+        ['&' ] = '&amp;',
+        ['<' ] = '&lt;',
+        ['>' ] = '&gt;',
         ['\n'] = '<br/>'
     }
     return txt

--- a/resources/[system]/scoreboard/scoreboard_sv.lua
+++ b/resources/[system]/scoreboard/scoreboard_sv.lua
@@ -1,0 +1,12 @@
+local Players = {}
+
+RegisterNetEvent("Scoreboard:ClientInitialized")
+AddEventHandler("Scoreboard:ClientInitialized", function()
+  Players[source] = GetPlayerName(source)
+  TriggerClientEvent("Scoreboard:GetPlayerList", -1, Players)
+end)
+
+AddEventHandler("playerDropped", function (reason)
+  Players[source] = false
+  TriggerClientEvent("Scoreboard:GetPlayerList", -1, Players)
+end)


### PR DESCRIPTION
[baseevents]
- Moved baseevents over to fxmanifest.lua
- Cleaned up deathevents.lua using correct indentation.
- Replaced old `GetPlayerByEntityID(killer)` function which looped through 32 ID's with `NetworkGetPlayerIndexFromPed(killer)`

[scoreboard]
- Added a server sided playerlist so we are able to list all players in the server rather than just those in your  scope. (Bigmode)