### PR TITLE
Chat: ignore successive dupes in oldMessages / reset oldMessageIndex on input close

### DIFF
--- a/resources/[gameplay]/chat/html/App.js
+++ b/resources/[gameplay]/chat/html/App.js
@@ -250,6 +250,7 @@ window.APP = {
       }
       this.message = '';
       this.showInput = false;
+      this.oldMessagesIndex = -1;
       clearInterval(this.focusTimer);
       this.resetShowWindowTimer();
     },

--- a/resources/[gameplay]/chat/html/App.js
+++ b/resources/[gameplay]/chat/html/App.js
@@ -235,7 +235,9 @@ window.APP = {
         post('http://chat/chatResult', JSON.stringify({
           message: this.message,
         }));
-        this.oldMessages.unshift(this.message);
+        if(this.message !== this.oldMessages[0]) {
+          this.oldMessages.unshift(this.message);
+        }
         this.oldMessagesIndex = -1;
         this.hideInput();
       } else {


### PR DESCRIPTION
# Ignore successive dupes in oldMessages

Assume chat: `/b /a /a /b`
Current behavior: `["/b", "/a", "/a", "/b"]`
NoSuccessiveDupes: `["/b", "/a", "/b"]`

I guess one could add an option for that but why would you ever want successive dupes?

# reset oldMessageIndex

Reset oldMessageIndex when closing input (via escape for example)