### PR TITLE
Adding 2 new events on typing and stop typing

### DIFF
--- a/resources/[gameplay]/chat/cl_chat.lua
+++ b/resources/[gameplay]/chat/cl_chat.lua
@@ -12,6 +12,8 @@ RegisterNetEvent('chat:addSuggestion')
 RegisterNetEvent('chat:addSuggestions')
 RegisterNetEvent('chat:removeSuggestion')
 RegisterNetEvent('chat:clear')
+RegisterNetEvent('chat:startTyping')
+RegisterNetEvent('chat:stopTyping')
 
 -- internal events
 RegisterNetEvent('__cfx_internal:serverPrint')
@@ -100,6 +102,7 @@ end)
 RegisterNUICallback('chatResult', function(data, cb)
   chatInputActive = false
   SetNuiFocus(false)
+  TriggerEvent('chat:stopTyping')
 
   if not data.canceled then
     local id = PlayerId()
@@ -199,6 +202,7 @@ Citizen.CreateThread(function()
       if IsControlPressed(0, isRDR and `INPUT_MP_TEXT_CHAT_ALL` or 245) --[[ INPUT_MP_TEXT_CHAT_ALL ]] then
         chatInputActive = true
         chatInputActivating = true
+        TriggerEvent('chat:startTyping')
 
         SendNUIMessage({
           type = 'ON_OPEN'


### PR DESCRIPTION
Added to the chat code 2 new events
```lua
RegisterNetEvent('chat:startTyping')
RegisterNetEvent('chat:stopTyping')
```
Calling `chat:startTyping` when the user starts write and `chat:stopTyping` when the player send, calcen or stop writing. 