### PR TITLE
[chat] Add server validation with convar

### DIFF
--- a/resources/[gameplay]/chat/sv_chat.lua
+++ b/resources/[gameplay]/chat/sv_chat.lua
@@ -6,10 +6,20 @@ RegisterServerEvent('chat:removeSuggestion')
 RegisterServerEvent('_chat:messageEntered')
 RegisterServerEvent('chat:clear')
 RegisterServerEvent('__cfx_internal:commandFallback')
+RegisterServerEvent('chat:validationFailed')
+
+isServerValidationEnabled = GetConvar("chat_senderValidation", "false") == "true"
 
 AddEventHandler('_chat:messageEntered', function(author, color, message)
+    local src = source
+
     if not message or not author then
         return
+    end
+    
+    if isServerValidationEnabled and GetPlayerName(src) ~= author then
+        CancelEvent()
+        TriggerEvent("chat:validationFailed", src, author, message)
     end
 
     TriggerEvent('chatMessage', source, author, message)


### PR DESCRIPTION
This PR adds a Convar that enables server validation for messages.

If the convar is `set chat_serverValidation "true"` and the message author mismatches the event's source player name, the message get's dropped.

I also added the event `chat:validationFailed` to be able to receive these drops in other server resources. Could be handy for admin tools.