### PR TITLE
fix: scroll bug when switching chat channel (isChannel)

### DIFF
--- a/resources/[gameplay]/chat/html/App.ts
+++ b/resources/[gameplay]/chat/html/App.ts
@@ -397,6 +397,9 @@ export default Vue.extend({
             this.modeIdx = (this.modeIdx + 1) % this.modes.length;
           } while (this.modes[this.modeIdx].hidden);
         }
+
+        const buf = document.getElementsByClassName('chat-messages')[0];
+        setTimeout(() => buf.scrollTop = buf.scrollHeight, 0);
       }
 
       this.resize();


### PR DESCRIPTION
This fixes a bug which will not scroll to the most recent message whenever you switch from one channel (isChannel) to another.

Apparently using `setTimeout` only works with this logic. Otherwise, nothing will be changed.