### PR TITLE
feat(chat): convar to stop console prints on msg route

### DIFF
--- a/resources/[gameplay]/chat/sv_chat.lua
+++ b/resources/[gameplay]/chat/sv_chat.lua
@@ -196,7 +196,7 @@ local function routeMessage(source, author, message, mode, fromConsole)
         end
     end
 
-    if not fromConsole then
+    if not fromConsole and GetConvarInt('chat_silent', 0) == 0 then
         print(author .. '^7' .. (modes[mode] and (' (' .. modes[mode].displayName .. ')') or '') .. ': ' .. message .. '^7')
     end
 end


### PR DESCRIPTION
Add a convar to be able to stop console prints when a message is routed. This does not change default behavior without setting the convar to something non-zero.

Usage for note:
```
set chat_silent 1 # disables prints to server console
```