### PR TITLE
prevent errors when passing a spawn table rather an index

### DIFF
--- a/resources/[managers]/spawnmanager/spawnmanager.lua
+++ b/resources/[managers]/spawnmanager/spawnmanager.lua
@@ -222,6 +222,13 @@ function spawnPlayer(spawnIdx, cb)
 
         if type(spawnIdx) == 'table' then
             spawn = spawnIdx
+
+            -- prevent errors when passing spawn table
+            spawn.x = spawn.x + 0.0001
+            spawn.y = spawn.y + 0.0001
+            spawn.z = spawn.z + 0.0001
+
+            spawn.heading = spawn.heading and (spawn.heading + 0.01) or 0
         else
             spawn = spawnPoints[spawnIdx]
         end

--- a/resources/[managers]/spawnmanager/spawnmanager.lua
+++ b/resources/[managers]/spawnmanager/spawnmanager.lua
@@ -224,11 +224,11 @@ function spawnPlayer(spawnIdx, cb)
             spawn = spawnIdx
 
             -- prevent errors when passing spawn table
-            spawn.x = spawn.x + 0.0001
-            spawn.y = spawn.y + 0.0001
-            spawn.z = spawn.z + 0.0001
+            spawn.x = spawn.x + 0.00
+            spawn.y = spawn.y + 0.00
+            spawn.z = spawn.z + 0.00
 
-            spawn.heading = spawn.heading and (spawn.heading + 0.01) or 0
+            spawn.heading = spawn.heading and (spawn.heading + 0.00) or 0
         else
             spawn = spawnPoints[spawnIdx]
         end


### PR DESCRIPTION
Currently, when sending a table as the spawn, the spawn will fail if there are not any decimal values. This is already being taken care of for the getMapDirectives addspawn. I copied some bits from there to make it act as intended for when we need to pass our own spawn.

Let me know if you need any changes.

Thanks