### PR TITLE
fix(chat): Filter removed suggestions array if suggestion is readded

### DIFF
--- a/resources/[gameplay]/chat/html/App.ts
+++ b/resources/[gameplay]/chat/html/App.ts
@@ -234,6 +234,7 @@ export default Vue.extend({
       this.oldMessagesIndex = -1;
     },
     ON_SUGGESTION_ADD({ suggestion }: { suggestion: Suggestion }) {
+      this.removedSuggestions = this.removedSuggestions.filter(a => a !== suggestion.name);
       const duplicateSuggestion = this.backingSuggestions.find(
         a => a.name == suggestion.name
       );


### PR DESCRIPTION
This filters the array for removed suggestions upon readding a suggestion.

The suggestion *may* still be in the backingSuggestions array, which is why this check is before the duplication check.