### PR TITLE
feat(chat): Allow 'togglechat' for RDR

### DIFF
--- a/resources/[gameplay]/chat/cl_chat.lua
+++ b/resources/[gameplay]/chat/cl_chat.lua
@@ -232,21 +232,21 @@ if not isRDR then
   if RegisterKeyMapping then
     RegisterKeyMapping('toggleChat', 'Toggle chat', 'keyboard', 'l')
   end
-
-  RegisterCommand('toggleChat', function()
-    if chatHideState == CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE then
-      chatHideState = CHAT_HIDE_STATES.ALWAYS_SHOW
-    elseif chatHideState == CHAT_HIDE_STATES.ALWAYS_SHOW then
-      chatHideState = CHAT_HIDE_STATES.ALWAYS_HIDE
-    elseif chatHideState == CHAT_HIDE_STATES.ALWAYS_HIDE then
-      chatHideState = CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE
-    end
-
-    isFirstHide = false
-
-    SetResourceKvp('hideState', tostring(chatHideState))
-  end, false)
 end
+
+RegisterCommand('toggleChat', function()
+  if chatHideState == CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE then
+    chatHideState = CHAT_HIDE_STATES.ALWAYS_SHOW
+  elseif chatHideState == CHAT_HIDE_STATES.ALWAYS_SHOW then
+    chatHideState = CHAT_HIDE_STATES.ALWAYS_HIDE
+  elseif chatHideState == CHAT_HIDE_STATES.ALWAYS_HIDE then
+    chatHideState = CHAT_HIDE_STATES.SHOW_WHEN_ACTIVE
+  end
+
+  isFirstHide = false
+
+  SetResourceKvp('hideState', tostring(chatHideState))
+end, false)
 
 Citizen.CreateThread(function()
   SetTextChatEnabled(false)


### PR DESCRIPTION
Allow RDR to use the togglechat command by default. All appears to be working so there is no reason to limit it.

Keymapping can still be left within the RDR check.