### PR TITLE
Replace 'GetPlayerByEntityId' with 'NetworkGetPlayerIndexFromPed'

### DIFF
--- a/resources/[system]/baseevents/deathevents.lua
+++ b/resources/[system]/baseevents/deathevents.lua
@@ -33,7 +33,7 @@ Citizen.CreateThread(function()
 					end
 				end
 
-				local killerid = GetPlayerByEntityID(killer)
+				local killerid = NetworkGetPlayerIndexFromPed(killer)
 				if killer ~= ped and killerid ~= nil and NetworkIsPlayerActive(killerid) then killerid = GetPlayerServerId(killerid)
 				else killerid = -1
 				end


### PR DESCRIPTION
seems like 'GetPlayerByEntityId' is no longer supported and always return -1 to onPlayerKilled event so, I replace it with 'NetworkGetPlayerIndexFromPed' to make it work properly.