### PR TITLE
Removed old deprecated RegisterServerEvent for RegisterNetEvent in hardcap and baseevents

### DIFF
--- a/resources/[system]/baseevents/server.lua
+++ b/resources/[system]/baseevents/server.lua
@@ -1,10 +1,10 @@
-RegisterServerEvent('baseevents:onPlayerDied')
-RegisterServerEvent('baseevents:onPlayerKilled')
-RegisterServerEvent('baseevents:onPlayerWasted')
-RegisterServerEvent('baseevents:enteringVehicle')
-RegisterServerEvent('baseevents:enteringAborted')
-RegisterServerEvent('baseevents:enteredVehicle')
-RegisterServerEvent('baseevents:leftVehicle')
+RegisterNetEvent('baseevents:onPlayerDied')
+RegisterNetEvent('baseevents:onPlayerKilled')
+RegisterNetEvent('baseevents:onPlayerWasted')
+RegisterNetEvent('baseevents:enteringVehicle')
+RegisterNetEvent('baseevents:enteringAborted')
+RegisterNetEvent('baseevents:enteredVehicle')
+RegisterNetEvent('baseevents:leftVehicle')
 
 AddEventHandler('baseevents:onPlayerKilled', function(killedBy, data)
 	local victim = source

--- a/resources/[system]/hardcap/server.lua
+++ b/resources/[system]/hardcap/server.lua
@@ -1,8 +1,7 @@
 local playerCount = 0
 local list = {}
 
-RegisterServerEvent('hardcap:playerActivated')
-
+RegisterNetEvent('hardcap:playerActivated')
 AddEventHandler('hardcap:playerActivated', function()
   if not list[source] then
     playerCount = playerCount + 1


### PR DESCRIPTION
Removed the old RegisterServerEvent calls for the new RegisterNetEvent to allow theses events to be called over the  net.