### PR TITLE
Fix missing skipFade check (potential softlock) for screen fade in

### DIFF
--- a/resources/[managers]/spawnmanager/spawnmanager.lua
+++ b/resources/[managers]/spawnmanager/spawnmanager.lua
@@ -313,7 +313,7 @@ function spawnPlayer(spawnIdx, cb)
 
         ShutdownLoadingScreen()
 
-        if IsScreenFadedOut() then
+        if not spawn.skipFade and IsScreenFadedOut() then
             DoScreenFadeIn(500)
 
             while not IsScreenFadedIn() do


### PR DESCRIPTION
While attempting to create a custom loading/spawn system using a combination of exports and events, while also wanting to manually control when and how the screen fades in and out (and setting skipFade true), the resource doesn't check for skipFade and forcefully fades the screen in no matter what, and should you override that forced fade in (by forcing a fade out at the same time via a while loop), nothing works, everything breaks, the playerSpawned event never fires and the spawning process never completes.

This commit change fixes the above, by adding a skipFade check where it was missing, to prevent a softlock from occurring when manually controlling screen fade, and prevent needing to have the screen fade in just to complete the spawning process.