### PR TITLE
fix (baseevents/deathevents): use GetConvarInt instead of hardcoded 32 for GetPlayerByEntityID(id).

### DIFF
--- a/resources/[system]/baseevents/deathevents.lua
+++ b/resources/[system]/baseevents/deathevents.lua
@@ -66,8 +66,8 @@ Citizen.CreateThread(function()
 end)
 
 function GetPlayerByEntityID(id)
-	for i=0,32 do
-		if(NetworkIsPlayerActive(i) and GetPlayerPed(i) == id) then return i end
-	end
-	return nil
+    for i=0,GetConvarInt('sv_maxclients', 32) do
+        if(NetworkIsPlayerActive(i) and GetPlayerPed(i) == id) then return i end
+    end
+    return nil
 end


### PR DESCRIPTION
This should hopefully remedy people needing to edit their base resources to listen for base death events.