### PR TITLE
fix(chat/client): don't refresh commands when joining

### DIFF
--- a/resources/[gameplay]/chat/cl_chat.lua
+++ b/resources/[gameplay]/chat/cl_chat.lua
@@ -193,7 +193,7 @@ local function refreshThemes()
   })
 end
 
-AddEventHandler('onClientResourceStart', function(resName)
+AddEventHandler('onResourceStart', function(resName)
   Wait(500)
 
   refreshCommands()


### PR DESCRIPTION
> Resource start events don't 'all trigger for every resource', these are supposed to only trigger when a resource gets started or stopped while already joined


'onClientResourceStart' is triggered when a resource has fully started, including when joining the server for the first time.  

'onResourceStart' has the intended behaviour and will not trigger unless restarting a resource while connected to the server.
