### PR TITLE
fix: removed empty lines from the build stdout

### DIFF
--- a/resources/[system]/[builders]/yarn/yarn_builder.js
+++ b/resources/[system]/[builders]/yarn/yarn_builder.js
@@ -4,7 +4,6 @@ const child_process = require('child_process');
 let buildingInProgress = false;
 let currentBuildingModule = '';
 
-const cliPath = require.resolve('./yarn_cli.js');
 const initCwd = process.cwd();
 const trimOutput = (data) => {
 	return `[yarn]\t` + data.toString().replace(/\s+$/, '');
@@ -14,15 +13,15 @@ const yarnBuildTask = {
 	shouldBuild(resourceName) {
 		try {
 			const resourcePath = GetResourcePath(resourceName);
-
+			
 			const packageJson = path.resolve(resourcePath, 'package.json');
 			const yarnLock = path.resolve(resourcePath, '.yarn.installed');
-
+			
 			const packageStat = fs.statSync(packageJson);
-
+			
 			try {
 				const yarnStat = fs.statSync(yarnLock);
-
+				
 				if (packageStat.mtimeMs > yarnStat.mtimeMs) {
 					return true;
 				}
@@ -31,12 +30,12 @@ const yarnBuildTask = {
 				return true;
 			}
 		} catch (e) {
-
+			
 		}
-
+		
 		return false;
 	},
-
+	
 	build(resourceName, cb) {
 		(async () => {
 			while (buildingInProgress && currentBuildingModule !== resourceName) {
@@ -46,7 +45,7 @@ const yarnBuildTask = {
 			buildingInProgress = true;
 			currentBuildingModule = resourceName;
 			const proc = child_process.fork(
-				cliPath,
+				require.resolve('./yarn_cli.js'),
 				['install', '--ignore-scripts', '--cache-folder', path.join(initCwd, 'cache', 'yarn-cache'), '--mutex', 'file:' + path.join(initCwd, 'cache', 'yarn-mutex')],
 				{
 					cwd: path.resolve(GetResourcePath(resourceName)),


### PR DESCRIPTION
Since #195 yarn stdout is printing one empty line for every `stdout` event, causing blank lines like shown below.  
Before: https://i.imgur.com/0rbnKXv.png  
After: https://i.imgur.com/0baqrX2.png  
  
I'm doing regex replace instead of `.trim()` to preserve any multiline output with indentation or something like that.  
Note that the code assumes every event will be a new line, and only a single line. If one event has multiple lines then the `[yarn]` tag will be broken.  
On second thought, probably better to even remove it since now all resource outputs are already tagged?! Let me know and can push a new commit removing it.
