### PR TITLE
Overall modernization work on the codebase

### DIFF
--- a/resources/[gamemodes]/[maps]/fivem-map-hipster/fxmanifest.lua
+++ b/resources/[gamemodes]/[maps]/fivem-map-hipster/fxmanifest.lua
@@ -10,5 +10,5 @@ resource_type 'map' { gameTypes = { ['basic-gamemode'] = true } }
 
 map 'map.lua'
 
-fx_version 'adamant'
+fx_version 'cerulean'
 games { 'gta5', 'gta5enhanced' }

--- a/resources/[gamemodes]/[maps]/fivem-map-hipster/map.lua
+++ b/resources/[gamemodes]/[maps]/fivem-map-hipster/map.lua
@@ -59,5 +59,3 @@ spawnpoint 'a_m_y_hipster_01' { x = 714.109, y = 4151.15, z = 35.7792 }
 spawnpoint 'a_m_y_hipster_02' { x = -103.651, y = -967.93, z = 296.52 }
 spawnpoint 'a_m_y_hipster_01' { x = -265.333, y = -2419.35, z = 122.366 }
 spawnpoint 'a_m_y_hipster_02' { x = 1788.25, y = 3890.34, z = 34.3849 }
-
---

--- a/resources/[gamemodes]/[maps]/fivem-map-skater/fxmanifest.lua
+++ b/resources/[gamemodes]/[maps]/fivem-map-skater/fxmanifest.lua
@@ -10,5 +10,5 @@ resource_type 'map' { gameTypes = { ['basic-gamemode'] = true } }
 
 map 'map.lua'
 
-fx_version 'adamant'
+fx_version 'cerulean'
 games { 'gta5', 'gta5enhanced' }

--- a/resources/[gamemodes]/[maps]/fivem-map-skater/map.lua
+++ b/resources/[gamemodes]/[maps]/fivem-map-skater/map.lua
@@ -58,5 +58,3 @@ spawnpoint 'a_m_y_skater_01' { x = 714.109, y = 4151.15, z = 35.7792 }
 spawnpoint 'a_m_y_skater_02' { x = -103.651, y = -967.93, z = 296.52 }
 spawnpoint 'a_m_y_skater_01' { x = -265.333, y = -2419.35, z = 122.366 }
 spawnpoint 'a_m_y_skater_02' { x = 1788.25, y = 3890.34, z = 34.3849 }
-
---

--- a/resources/[gamemodes]/[maps]/redm-map-one/fxmanifest.lua
+++ b/resources/[gamemodes]/[maps]/redm-map-one/fxmanifest.lua
@@ -10,7 +10,7 @@ resource_type 'map' { gameTypes = { ['basic-gamemode'] = true } }
 
 map 'map.lua'
 
-fx_version 'adamant'
+fx_version 'cerulean'
 game 'rdr3'
 
 rdr3_warning 'I acknowledge that this is a prerelease build of RedM, and I am aware my resources *will* become incompatible once RedM ships.'

--- a/resources/[gamemodes]/basic-gamemode/fxmanifest.lua
+++ b/resources/[gamemodes]/basic-gamemode/fxmanifest.lua
@@ -11,4 +11,4 @@ resource_type 'gametype' { name = 'Freeroam' }
 client_script 'basic_client.lua'
 
 game 'common'
-fx_version 'adamant'
+fx_version 'cerulean'

--- a/resources/[gameplay]/[examples]/money-fountain/fxmanifest.lua
+++ b/resources/[gameplay]/[examples]/money-fountain/fxmanifest.lua
@@ -6,7 +6,7 @@ description 'An example money system client containing a money fountain.'
 repository 'https://github.com/citizenfx/cfx-server-data'
 author 'Cfx.re <root@cfx.re>'
 
-fx_version 'bodacious'
+fx_version 'cerulean'
 game 'gta5'
 
 client_script 'client.lua'

--- a/resources/[gameplay]/[examples]/money-fountain/server.lua
+++ b/resources/[gameplay]/[examples]/money-fountain/server.lua
@@ -80,14 +80,12 @@ local function handleFountainStuff(source, id, pickup)
 end
 
 -- event for picking up fountain->player
-RegisterNetEvent('money_fountain:tryPickup')
-AddEventHandler('money_fountain:tryPickup', function(id)
+RegisterNetEvent('money_fountain:tryPickup', function(id)
     handleFountainStuff(source, id, true)
 end)
 
 -- event for donating player->fountain
-RegisterNetEvent('money_fountain:tryPlace')
-AddEventHandler('money_fountain:tryPlace', function(id)
+RegisterNetEvent('money_fountain:tryPlace', function(id)
     handleFountainStuff(source, id, false)
 end)
 

--- a/resources/[gameplay]/[examples]/money/client.lua
+++ b/resources/[gameplay]/[examples]/money/client.lua
@@ -3,9 +3,7 @@ local moneyTypes = {
     bank = `BANK_BALANCE`,
 }
 
-RegisterNetEvent('money:displayUpdate')
-
-AddEventHandler('money:displayUpdate', function(type, money)
+RegisterNetEvent('money:displayUpdate', function(type, money)
     local stat = moneyTypes[type]
     if not stat then return end
     StatSetInt(stat, math.floor(money))

--- a/resources/[gameplay]/[examples]/money/fxmanifest.lua
+++ b/resources/[gameplay]/[examples]/money/fxmanifest.lua
@@ -6,11 +6,10 @@ description 'An example money system using KVS.'
 repository 'https://github.com/citizenfx/cfx-server-data'
 author 'Cfx.re <root@cfx.re>'
 
-fx_version 'bodacious'
+fx_version 'cerulean'
 game 'gta5'
 
 client_script 'client.lua'
 server_script 'server.lua'
 
---dependency 'cfx.re/playerData.v1alpha1'
 lua54 'yes'

--- a/resources/[gameplay]/[examples]/money/fxmanifest.lua
+++ b/resources/[gameplay]/[examples]/money/fxmanifest.lua
@@ -13,3 +13,5 @@ client_script 'client.lua'
 server_script 'server.lua'
 
 lua54 'yes'
+
+dependency 'player-data'

--- a/resources/[gameplay]/[examples]/money/server.lua
+++ b/resources/[gameplay]/[examples]/money/server.lua
@@ -1,4 +1,4 @@
-local playerData = exports['cfx.re/playerData.v1alpha1']
+local playerData = exports['player-data']
 
 local validMoneyTypes = {
     bank = true,
@@ -88,9 +88,7 @@ AddEventHandler('money:updated', function(data)
     end
 end)
 
-RegisterNetEvent('money:requestDisplay')
-
-AddEventHandler('money:requestDisplay', function()
+RegisterNetEvent('money:requestDisplay', function()
     local source = source
     local playerId = playerData:getPlayerId(source)
 

--- a/resources/[gameplay]/[examples]/ped-money-drops/client.lua
+++ b/resources/[gameplay]/[examples]/ped-money-drops/client.lua
@@ -1,7 +1,6 @@
 AddEventHandler('gameEventTriggered', function(eventName, args)
     if eventName == 'CEventNetworkEntityDamage' then
         local victim = args[1]
-        local culprit = args[2]
         local isDead = args[6] == 1
 
         if isDead then

--- a/resources/[gameplay]/[examples]/ped-money-drops/fxmanifest.lua
+++ b/resources/[gameplay]/[examples]/ped-money-drops/fxmanifest.lua
@@ -6,7 +6,7 @@ description 'An example money system client.'
 author 'Cfx.re <root@cfx.re>'
 repository 'https://github.com/citizenfx/cfx-server-data'
 
-fx_version 'bodacious'
+fx_version 'cerulean'
 game 'gta5'
 
 client_script 'client.lua'

--- a/resources/[gameplay]/[examples]/ped-money-drops/server.lua
+++ b/resources/[gameplay]/[examples]/ped-money-drops/server.lua
@@ -1,8 +1,6 @@
 local safePositions = {}
 
-RegisterNetEvent('money:allowPickupNear')
-
-AddEventHandler('money:allowPickupNear', function(pedId)
+RegisterNetEvent('money:allowPickupNear', function(pedId)
     local entity = NetworkGetEntityFromNetworkId(pedId)
 
     Wait(250)
@@ -19,9 +17,7 @@ AddEventHandler('money:allowPickupNear', function(pedId)
     safePositions[pedId] = coords
 end)
 
-RegisterNetEvent('money:tryPickup')
-
-AddEventHandler('money:tryPickup', function(entity)
+RegisterNetEvent('money:tryPickup', function(entity)
     if not safePositions[entity] then
         return
     end

--- a/resources/[gameplay]/player-data/fxmanifest.lua
+++ b/resources/[gameplay]/player-data/fxmanifest.lua
@@ -6,11 +6,7 @@ description 'A basic resource for storing player identifiers.'
 author 'Cfx.re <root@cfx.re>'
 repository 'https://github.com/citizenfx/cfx-server-data'
 
-fx_version 'bodacious'
+fx_version 'cerulean'
 game 'common'
 
 server_script 'server.lua'
-
-provides {
-    'cfx.re/playerData.v1alpha1'
-}

--- a/resources/[gameplay]/player-data/server.lua
+++ b/resources/[gameplay]/player-data/server.lua
@@ -130,7 +130,7 @@ AddEventHandler('playerConnecting', function()
 end)
 
 -- and migrate them to a 'joining' ID where possible
-RegisterNetEvent('playerJoining', function(oldIdx)
+AddEventHandler('playerJoining', function(oldIdx)
     -- resource restart race condition
     local oldPlayer = players[tostring(oldIdx)]
 

--- a/resources/[gameplay]/player-data/server.lua
+++ b/resources/[gameplay]/player-data/server.lua
@@ -3,7 +3,7 @@
 -- it works in a fairly simple way: a set of identifiers is assigned to an account ID, and said
 -- account ID is then returned/added as state bag
 --
--- it also implements the `cfx.re/playerData.v1alpha1` spec, which is exposed through the following:
+-- it also implements the `player-data` spec, which is exposed through the following:
 -- - getPlayerId(source: string)
 -- - getPlayerById(dbId: string)
 -- - getPlayerIdFromIdentifier(identifier: string)
@@ -130,9 +130,7 @@ AddEventHandler('playerConnecting', function()
 end)
 
 -- and migrate them to a 'joining' ID where possible
-RegisterNetEvent('playerJoining')
-
-AddEventHandler('playerJoining', function(oldIdx)
+RegisterNetEvent('playerJoining', function(oldIdx)
     -- resource restart race condition
     local oldPlayer = players[tostring(oldIdx)]
 
@@ -189,25 +187,10 @@ RegisterCommand('playerData', function(source, args)
     end
 end, true)
 
--- COMPATIBILITY for server versions that don't export provide
-local function getExportEventName(resource, name)
-	return string.format('__cfx_export_%s_%s', resource, name)
-end
-
-function AddExport(name, fn)
-    if not Citizen.Traits or not Citizen.Traits.ProvidesExports then
-        AddEventHandler(getExportEventName('cfx.re/playerData.v1alpha1', name), function(setCB)
-            setCB(fn)
-        end)
-    end
-
-    exports(name, fn)
-end
-
 -- exports
-AddExport('getPlayerIdFromIdentifier', getPlayerIdFromIdentifier)
+exports('getPlayerIdFromIdentifier', getPlayerIdFromIdentifier)
 
-AddExport('getPlayerId', function(playerIdx)
+exports('getPlayerId', function(playerIdx)
     local player = players[tostring(playerIdx)]
 
     if not player then
@@ -217,6 +200,6 @@ AddExport('getPlayerId', function(playerIdx)
     return player.dbId
 end)
 
-AddExport('getPlayerById', function(playerId)
+exports('getPlayerById', function(playerId)
     return playersById[tostring(playerId)]
 end)

--- a/resources/[gameplay]/playernames/fxmanifest.lua
+++ b/resources/[gameplay]/playernames/fxmanifest.lua
@@ -13,24 +13,11 @@ server_script 'playernames_api.lua'
 client_script 'playernames_cl.lua'
 server_script 'playernames_sv.lua'
 
--- make exports
-local exportList = {
-    'setComponentColor',
-    'setComponentAlpha',
-    'setComponentVisibility',
-    'setWantedLevel',
-    'setHealthBarColor',
-    'setNameTemplate'
-}
-
-exports(exportList)
-server_exports(exportList)
-
 -- add files
 files {
     'template/template.lua'
 }
 
 -- support the latest resource manifest
-fx_version 'adamant'
+fx_version 'cerulean'
 game 'gta5'

--- a/resources/[gameplay]/playernames/playernames_api.lua
+++ b/resources/[gameplay]/playernames/playernames_api.lua
@@ -42,6 +42,13 @@ setHealthBarColor = getTriggerFunction('sehc')
 setNameTemplate = getTriggerFunction('tpl')
 setName = getTriggerFunction('name')
 
+exports('setComponentColor', setComponentColor)
+exports('setComponentAlpha', setComponentAlpha)
+exports('setComponentVisibility', setComponentVisibility)
+exports('setWantedLevel', setWantedLevel)
+exports('setHealthBarColor', setHealthBarColor)
+exports('setNameTemplate', setNameTemplate)
+
 if not io then
     io = { write = nil, open = nil }
 end

--- a/resources/[gameplay]/playernames/playernames_cl.lua
+++ b/resources/[gameplay]/playernames/playernames_cl.lua
@@ -142,9 +142,7 @@ local function getSettings(id)
     return mpGamerTagSettings[i]
 end
 
-RegisterNetEvent('playernames:configure')
-
-AddEventHandler('playernames:configure', function(id, key, ...)
+RegisterNetEvent('playernames:configure', function(id, key, ...)
     local args = table.pack(...)
 
     if key == 'tglc' then
@@ -183,7 +181,7 @@ AddEventHandler('onResourceStop', function(name)
     end
 end)
 
-SetTimeout(0, function()
+CreateThread(function()
     TriggerServerEvent('playernames:init')
 end)
 

--- a/resources/[gameplay]/playernames/playernames_sv.lua
+++ b/resources/[gameplay]/playernames/playernames_sv.lua
@@ -7,7 +7,7 @@ local function detectUpdates()
     SetTimeout(500, detectUpdates)
 
     local template = GetConvar('playerNames_template', '[{{id}}] {{name}}')
-    
+
     if curTemplate ~= template then
         setNameTemplate(-1, template)
 
@@ -20,7 +20,7 @@ local function detectUpdates()
         local newTag = formatPlayerNameTag(v, template)
         if newTag ~= curTags[v] then
             setName(v, newTag)
-            
+
             curTags[v] = newTag
         end
     end
@@ -37,8 +37,7 @@ AddEventHandler('playerDropped', function()
     activePlayers[source] = nil
 end)
 
-RegisterNetEvent('playernames:init')
-AddEventHandler('playernames:init', function()
+RegisterNetEvent('playernames:init', function()
     reconfigure(source)
     activePlayers[source] = true
 end)

--- a/resources/[managers]/mapmanager/fxmanifest.lua
+++ b/resources/[managers]/mapmanager/fxmanifest.lua
@@ -6,25 +6,13 @@ author 'Cfx.re <root@cfx.re>'
 description 'A flexible handler for game type/map association.'
 repository 'https://github.com/citizenfx/cfx-server-data'
 
-client_scripts {
-    "mapmanager_shared.lua",
-    "mapmanager_client.lua"
-}
+client_script 'mapmanager_client.lua'
 
-server_scripts {
-    "mapmanager_shared.lua",
-    "mapmanager_server.lua"
-}
+server_script 'mapmanager_server.lua'
 
-fx_version 'adamant'
+shared_script 'mapmanager_shared.lua'
+
+fx_version 'cerulean'
 games { 'gta5', 'rdr3' }
-
-server_export "getCurrentGameType"
-server_export "getCurrentMap"
-server_export "changeGameType"
-server_export "changeMap"
-server_export "doesMapSupportGameType"
-server_export "getMaps"
-server_export "roundEnded"
 
 rdr3_warning 'I acknowledge that this is a prerelease build of RedM, and I am aware my resources *will* become incompatible once RedM ships.'

--- a/resources/[managers]/mapmanager/mapmanager_client.lua
+++ b/resources/[managers]/mapmanager/mapmanager_client.lua
@@ -40,8 +40,8 @@ AddEventHandler('onClientResourceStart', function(res)
     loadMap(res)
 
     -- defer this to the next game tick to work around a lack of dependencies
-    Citizen.CreateThread(function()
-        Citizen.Wait(15)
+    CreateThread(function()
+        Wait(15)
 
         if maps[res] then
             TriggerEvent('onClientMapStart', res)

--- a/resources/[managers]/mapmanager/mapmanager_server.lua
+++ b/resources/[managers]/mapmanager/mapmanager_server.lua
@@ -12,14 +12,14 @@ local function refreshResources()
         if GetNumResourceMetadata(resource, 'resource_type') > 0 then
             local type = GetResourceMetadata(resource, 'resource_type', 0)
             local params = json.decode(GetResourceMetadata(resource, 'resource_type_extra', 0))
-            
+
             local valid = false
-            
+
             local games = GetNumResourceMetadata(resource, 'game')
             if games > 0 then
 				for j = 0, games - 1 do
 					local game = GetResourceMetadata(resource, 'game', j)
-				
+
 					if game == GetConvar('gamename', 'gta5') or game == 'common' then
 						valid = true
 					end
@@ -264,7 +264,7 @@ RegisterCommand("gametype", function(source, args)
     end
     changeGameType(args[1])
     print('gametype ' .. args[1] .. "\n")
-end)
+end, true)
 
 function getCurrentGameType()
     return currentGameType
@@ -313,3 +313,11 @@ function doesMapSupportGameType(gameType, map)
 
     return maps[map].gameTypes[gameType]
 end
+
+exports('getCurrentGameType', getCurrentGameType)
+exports('getCurrentMap', getCurrentMap)
+exports('changeGameType', changeGameType)
+exports('changeMap', changeMap)
+exports('doesMapSupportGameType', doesMapSupportGameType)
+exports('getMaps', getMaps)
+exports('roundEnded', roundEnded)

--- a/resources/[managers]/mapmanager/mapmanager_shared.lua
+++ b/resources/[managers]/mapmanager/mapmanager_shared.lua
@@ -74,7 +74,7 @@ function parseMap(file, owningResource)
     }
 
     setmetatable(env, mt)
-    
+
     local fileData = LoadResourceFile(owningResource, file)
     local mapFunction, err = load(fileData, file, 't', env)
 

--- a/resources/[managers]/spawnmanager/fxmanifest.lua
+++ b/resources/[managers]/spawnmanager/fxmanifest.lua
@@ -8,7 +8,7 @@ repository 'https://github.com/citizenfx/cfx-server-data'
 
 client_script 'spawnmanager.lua'
 
-fx_version 'adamant'
+fx_version 'cerulean'
 games { 'rdr3', 'gta5' }
 
 rdr3_warning 'I acknowledge that this is a prerelease build of RedM, and I am aware my resources *will* become incompatible once RedM ships.'

--- a/resources/[managers]/spawnmanager/spawnmanager.lua
+++ b/resources/[managers]/spawnmanager/spawnmanager.lua
@@ -41,7 +41,7 @@ AddEventHandler('getMapDirectives', function(add)
 
                 -- recalculate the model for storage
                 if not tonumber(model) then
-                    model = GetHashKey(model, _r)
+                    model = GetHashKey(model)
                 end
 
                 -- store the spawn data in the state so we can erase it later on
@@ -110,11 +110,10 @@ function addSpawnPoint(spawn)
         error("invalid spawn model")
     end
 
-    -- is is even a ped?
-    -- not in V?
-    --[[if not IsThisModelAPed(model) then
+    -- is the model a ped?
+    if not IsModelAPed(model) then
         error("this model ain't a ped!")
-    end]]
+    end
 
     -- overwrite the model in case we hashed it
     spawn.model = model
@@ -153,32 +152,31 @@ end
 -- function as existing in original R* scripts
 local function freezePlayer(id, freeze)
     local player = id
-    SetPlayerControl(player, not freeze, false)
+    SetPlayerControl(player, not freeze, 0)
 
     local ped = GetPlayerPed(player)
 
     if not freeze then
         if not IsEntityVisible(ped) then
-            SetEntityVisible(ped, true)
+            SetEntityVisible(ped, true, false)
         end
 
-        if not IsPedInAnyVehicle(ped) then
-            SetEntityCollision(ped, true)
+        if not IsPedInAnyVehicle(ped, false) then
+            SetEntityCollision(ped, true, true)
         end
 
         FreezeEntityPosition(ped, false)
-        --SetCharNeverTargetted(ped, false)
+        SetPedCanBeTargetted(ped, true)
         SetPlayerInvincible(player, false)
     else
         if IsEntityVisible(ped) then
-            SetEntityVisible(ped, false)
+            SetEntityVisible(ped, false, false)
         end
 
-        SetEntityCollision(ped, false)
+        SetEntityCollision(ped, false, false)
         FreezeEntityPosition(ped, true)
-        --SetCharNeverTargetted(ped, true)
+        SetPedCanBeTargetted(ped, false)
         SetPlayerInvincible(player, true)
-        --RemovePtfxFromPed(ped)
 
         if not IsPedFatallyInjured(ped) then
             ClearPedTasksImmediately(ped)
@@ -187,17 +185,11 @@ local function freezePlayer(id, freeze)
 end
 
 function loadScene(x, y, z)
-	if not NewLoadSceneStart then
-		return
-	end
+	if not NewLoadSceneStart then return end
 
     NewLoadSceneStart(x, y, z, 0.0, 0.0, 0.0, 20.0, 0)
 
-    while IsNewLoadSceneActive() do
-        networkTimer = GetNetworkTimer()
-
-        NetworkUpdateLoadScene()
-    end
+    while IsNewLoadSceneActive() do NetworkUpdateLoadScene() end
 end
 
 -- to prevent trying to spawn multiple times
@@ -205,13 +197,11 @@ local spawnLock = false
 
 -- spawns the current player at a certain spawn point index (or a random one, for that matter)
 function spawnPlayer(spawnIdx, cb)
-    if spawnLock then
-        return
-    end
+    if spawnLock then return end
 
     spawnLock = true
 
-    Citizen.CreateThread(function()
+    CreateThread(function()
         -- if the spawn isn't set, select a random one
         if not spawnIdx then
             spawnIdx = GetRandomIntInRange(1, #spawnPoints + 1)
@@ -237,7 +227,7 @@ function spawnPlayer(spawnIdx, cb)
             DoScreenFadeOut(500)
 
             while not IsScreenFadedOut() do
-                Citizen.Wait(0)
+                Wait(0)
             end
         end
 
@@ -308,7 +298,7 @@ function spawnPlayer(spawnIdx, cb)
         local time = GetGameTimer()
 
         while (not HasCollisionLoadedAroundEntity(ped) and (GetGameTimer() - time) < 5000) do
-            Citizen.Wait(0)
+            Wait(0)
         end
 
         ShutdownLoadingScreen()
@@ -317,7 +307,7 @@ function spawnPlayer(spawnIdx, cb)
             DoScreenFadeIn(500)
 
             while not IsScreenFadedIn() do
-                Citizen.Wait(0)
+                Wait(0)
             end
         end
 
@@ -338,10 +328,10 @@ end
 local respawnForced
 local diedAt
 
-Citizen.CreateThread(function()
+CreateThread(function()
     -- main loop thing
     while true do
-        Citizen.Wait(50)
+        Wait(50)
 
         local playerPed = PlayerPedId()
 

--- a/resources/[system]/baseevents/deathevents.lua
+++ b/resources/[system]/baseevents/deathevents.lua
@@ -1,66 +1,84 @@
-Citizen.CreateThread(function()
+CreateThread(function()
+    while not NetworkIsPlayerActive(PlayerId()) do Wait(0) end
+    while not DoesEntityExist(PlayerPedId()) do Wait(0) end
+
     local isDead = false
     local hasBeenDead = false
-	local diedAt
+    local diedAt
 
     while true do
-        Wait(0)
-
+        local sleep = 500
         local player = PlayerId()
 
-        if NetworkIsPlayerActive(player) then
-            local ped = PlayerPedId()
+        local ped = PlayerPedId()
+        local fatallyInjured = IsPedFatallyInjured(ped)
 
-            if IsPedFatallyInjured(ped) and not isDead then
-                isDead = true
-                if not diedAt then
-                	diedAt = GetGameTimer()
-                end
-
-                local killer, killerweapon = NetworkGetEntityKillerOfPlayer(player)
-				local killerentitytype = GetEntityType(killer)
-				local killertype = -1
-				local killerinvehicle = false
-				local killervehiclename = ''
-                local killervehicleseat = 0
-				if killerentitytype == 1 then
-					killertype = GetPedType(killer)
-					if IsPedInAnyVehicle(killer, false) == 1 then
-						killerinvehicle = true
-						killervehiclename = GetDisplayNameFromVehicleModel(GetEntityModel(GetVehiclePedIsUsing(killer)))
-                        killervehicleseat = GetPedVehicleSeat(killer)
-					else killerinvehicle = false
-					end
-				end
-
-				local killerid = NetworkGetPlayerIndexFromPed(killer)
-				if killer ~= ped and killerid ~= -1 and NetworkIsPlayerActive(killerid) then killerid = GetPlayerServerId(killerid)
-				else killerid = -1
-				end
-
-                if killer == ped or killer == -1 then
-                    TriggerEvent('baseevents:onPlayerDied', killertype, { table.unpack(GetEntityCoords(ped)) })
-                    TriggerServerEvent('baseevents:onPlayerDied', killertype, { table.unpack(GetEntityCoords(ped)) })
-                    hasBeenDead = true
-                else
-                    TriggerEvent('baseevents:onPlayerKilled', killerid, {killertype=killertype, weaponhash = killerweapon, killerinveh=killerinvehicle, killervehseat=killervehicleseat, killervehname=killervehiclename, killerpos={table.unpack(GetEntityCoords(ped))}})
-                    TriggerServerEvent('baseevents:onPlayerKilled', killerid, {killertype=killertype, weaponhash = killerweapon, killerinveh=killerinvehicle, killervehseat=killervehicleseat, killervehname=killervehiclename, killerpos={table.unpack(GetEntityCoords(ped))}})
-                    hasBeenDead = true
-                end
-            elseif not IsPedFatallyInjured(ped) then
-                isDead = false
-                diedAt = nil
+        if fatallyInjured and not isDead then
+            isDead = true
+            sleep = 0
+            if not diedAt then
+                diedAt = GetGameTimer()
             end
 
-            -- check if the player has to respawn in order to trigger an event
-            if not hasBeenDead and diedAt ~= nil and diedAt > 0 then
-                TriggerEvent('baseevents:onPlayerWasted', { table.unpack(GetEntityCoords(ped)) })
-                TriggerServerEvent('baseevents:onPlayerWasted', { table.unpack(GetEntityCoords(ped)) })
+            local killer, killerweapon = NetworkGetEntityKillerOfPlayer(player)
+            local killerentitytype = GetEntityType(killer)
+            local killertype = -1
+            local killerinvehicle = false
+            local killervehiclename = ''
+            local killervehicleseat = 0
 
-                hasBeenDead = true
-            elseif hasBeenDead and diedAt ~= nil and diedAt <= 0 then
-                hasBeenDead = false
+            if killerentitytype == 1 then
+                killertype = GetPedType(killer)
+                if IsPedInAnyVehicle(killer, false) then
+                    local killerVehicle = GetVehiclePedIsUsing(killer)
+                    killerinvehicle = true
+                    killervehiclename = GetDisplayNameFromVehicleModel(GetEntityModel(killerVehicle))
+                    killervehicleseat = GetPedVehicleSeat(killer, killerVehicle)
+                end
             end
+
+            local killerid = NetworkGetPlayerIndexFromPed(killer)
+            if killer ~= ped and killerid ~= -1 and NetworkIsPlayerActive(killerid) then
+                killerid = GetPlayerServerId(killerid)
+            else
+                killerid = -1
+            end
+
+            local coords = { table.unpack(GetEntityCoords(ped)) }
+
+            if killer == ped or killer == -1 then
+                TriggerEvent('baseevents:onPlayerDied', killertype, coords)
+                TriggerServerEvent('baseevents:onPlayerDied', killertype, coords)
+            else
+                local killerData = {
+                    killertype = killertype,
+                    weaponhash = killerweapon,
+                    killerinveh = killerinvehicle,
+                    killervehseat = killervehicleseat,
+                    killervehname = killervehiclename,
+                    killerpos = coords
+                }
+                TriggerEvent('baseevents:onPlayerKilled', killerid, killerData)
+                TriggerServerEvent('baseevents:onPlayerKilled', killerid, killerData)
+            end
+            hasBeenDead = true
+
+        elseif not fatallyInjured and isDead then
+            isDead = false
+            diedAt = nil
+            sleep = 0
         end
+
+        if not hasBeenDead and diedAt ~= nil then
+            local coords = { table.unpack(GetEntityCoords(ped)) }
+            TriggerEvent('baseevents:onPlayerWasted', coords)
+            TriggerServerEvent('baseevents:onPlayerWasted', coords)
+            hasBeenDead = true
+            sleep = 0
+        elseif hasBeenDead and diedAt == nil then
+            hasBeenDead = false
+        end
+
+        Wait(sleep)
     end
 end)

--- a/resources/[system]/baseevents/fxmanifest.lua
+++ b/resources/[system]/baseevents/fxmanifest.lua
@@ -10,5 +10,5 @@ client_script 'deathevents.lua'
 client_script 'vehiclechecker.lua'
 server_script 'server.lua'
 
-fx_version 'adamant'
+fx_version 'cerulean'
 game 'gta5'

--- a/resources/[system]/baseevents/server.lua
+++ b/resources/[system]/baseevents/server.lua
@@ -1,19 +1,16 @@
-RegisterServerEvent('baseevents:onPlayerDied')
-RegisterServerEvent('baseevents:onPlayerKilled')
-RegisterServerEvent('baseevents:onPlayerWasted')
-RegisterServerEvent('baseevents:enteringVehicle')
-RegisterServerEvent('baseevents:enteringAborted')
-RegisterServerEvent('baseevents:enteredVehicle')
-RegisterServerEvent('baseevents:leftVehicle')
+RegisterNetEvent('baseevents:onPlayerWasted')
+RegisterNetEvent('baseevents:enteringVehicle')
+RegisterNetEvent('baseevents:enteringAborted')
+RegisterNetEvent('baseevents:enteredVehicle')
+RegisterNetEvent('baseevents:leftVehicle')
 
-AddEventHandler('baseevents:onPlayerKilled', function(killedBy, data)
+RegisterNetEvent('baseevents:onPlayerKilled', function(killedBy, data)
 	local victim = source
 
 	RconLog({msgType = 'playerKilled', victim = victim, attacker = killedBy, data = data})
 end)
 
-AddEventHandler('baseevents:onPlayerDied', function(killedBy, pos)
+RegisterNetEvent('baseevents:onPlayerDied', function(killedBy, pos)
 	local victim = source
-
 	RconLog({msgType = 'playerDied', victim = victim, attackerType = killedBy, pos = pos})
 end)

--- a/resources/[system]/baseevents/server.lua
+++ b/resources/[system]/baseevents/server.lua
@@ -3,14 +3,5 @@ RegisterNetEvent('baseevents:enteringVehicle')
 RegisterNetEvent('baseevents:enteringAborted')
 RegisterNetEvent('baseevents:enteredVehicle')
 RegisterNetEvent('baseevents:leftVehicle')
-
-RegisterNetEvent('baseevents:onPlayerKilled', function(killedBy, data)
-	local victim = source
-
-	RconLog({msgType = 'playerKilled', victim = victim, attacker = killedBy, data = data})
-end)
-
-RegisterNetEvent('baseevents:onPlayerDied', function(killedBy, pos)
-	local victim = source
-	RconLog({msgType = 'playerDied', victim = victim, attackerType = killedBy, pos = pos})
-end)
+RegisterNetEvent('baseevents:onPlayerKilled')
+RegisterNetEvent('baseevents:onPlayerDied')

--- a/resources/[system]/baseevents/vehiclechecker.lua
+++ b/resources/[system]/baseevents/vehiclechecker.lua
@@ -3,55 +3,53 @@ local isEnteringVehicle = false
 local currentVehicle = 0
 local currentSeat = 0
 
-Citizen.CreateThread(function()
-	while true do
-		Citizen.Wait(0)
+CreateThread(function()
+    while true do
+        local sleep = 500
+        local ped = PlayerPedId()
+        local playerId = PlayerId()
 
-		local ped = PlayerPedId()
+        if not isInVehicle and not IsPlayerDead(playerId) then
+            local vehicleTryingToEnter = GetVehiclePedIsTryingToEnter(ped)
+            local tryingToEnter = DoesEntityExist(vehicleTryingToEnter)
 
-		if not isInVehicle and not IsPlayerDead(PlayerId()) then
-			if DoesEntityExist(GetVehiclePedIsTryingToEnter(ped)) and not isEnteringVehicle then
-				-- trying to enter a vehicle!
-				local vehicle = GetVehiclePedIsTryingToEnter(ped)
-				local seat = GetSeatPedIsTryingToEnter(ped)
-				local netId = VehToNet(vehicle)
-				isEnteringVehicle = true
-				TriggerServerEvent('baseevents:enteringVehicle', vehicle, seat, GetDisplayNameFromVehicleModel(GetEntityModel(vehicle)), netId)
-			elseif not DoesEntityExist(GetVehiclePedIsTryingToEnter(ped)) and not IsPedInAnyVehicle(ped, true) and isEnteringVehicle then
-				-- vehicle entering aborted
-				TriggerServerEvent('baseevents:enteringAborted')
-				isEnteringVehicle = false
-			elseif IsPedInAnyVehicle(ped, false) then
-				-- suddenly appeared in a vehicle, possible teleport
-				isEnteringVehicle = false
-				isInVehicle = true
-				currentVehicle = GetVehiclePedIsUsing(ped)
-				currentSeat = GetPedVehicleSeat(ped)
-				local model = GetEntityModel(currentVehicle)
-				local name = GetDisplayNameFromVehicleModel()
-				local netId = VehToNet(currentVehicle)
-				TriggerServerEvent('baseevents:enteredVehicle', currentVehicle, currentSeat, GetDisplayNameFromVehicleModel(GetEntityModel(currentVehicle)), netId)
-			end
-		elseif isInVehicle then
-			if not IsPedInAnyVehicle(ped, false) or IsPlayerDead(PlayerId()) then
-				-- bye, vehicle
-				local model = GetEntityModel(currentVehicle)
-				local name = GetDisplayNameFromVehicleModel()
-				local netId = VehToNet(currentVehicle)
-				TriggerServerEvent('baseevents:leftVehicle', currentVehicle, currentSeat, GetDisplayNameFromVehicleModel(GetEntityModel(currentVehicle)), netId)
-				isInVehicle = false
-				currentVehicle = 0
-				currentSeat = 0
-			end
-		end
-		Citizen.Wait(50)
-	end
+            if tryingToEnter and not isEnteringVehicle then
+                local seat = GetSeatPedIsTryingToEnter(ped)
+                isEnteringVehicle = true
+                sleep = 0
+                TriggerServerEvent('baseevents:enteringVehicle', vehicleTryingToEnter, seat, GetDisplayNameFromVehicleModel(GetEntityModel(vehicleTryingToEnter)), VehToNet(vehicleTryingToEnter))
+            elseif not tryingToEnter and not IsPedInAnyVehicle(ped, true) and isEnteringVehicle then
+                isEnteringVehicle = false
+                sleep = 0
+                TriggerServerEvent('baseevents:enteringAborted')
+            elseif IsPedInAnyVehicle(ped, false) then
+                isEnteringVehicle = false
+                isInVehicle = true
+                currentVehicle = GetVehiclePedIsUsing(ped)
+                currentSeat = GetPedVehicleSeat(ped, currentVehicle)
+                sleep = 0
+                TriggerServerEvent('baseevents:enteredVehicle', currentVehicle, currentSeat, GetDisplayNameFromVehicleModel(GetEntityModel(currentVehicle)), VehToNet(currentVehicle))
+            elseif isEnteringVehicle then
+                sleep = 0
+            end
+        elseif isInVehicle then
+            if not IsPedInAnyVehicle(ped, false) or IsPlayerDead(playerId) then
+                isInVehicle = false
+                sleep = 0
+                TriggerServerEvent('baseevents:leftVehicle', currentVehicle, currentSeat, GetDisplayNameFromVehicleModel(GetEntityModel(currentVehicle)), VehToNet(currentVehicle))
+                currentVehicle = 0
+                currentSeat = 0
+            end
+        end
+
+        Wait(sleep)
+    end
 end)
 
-function GetPedVehicleSeat(ped)
-    local vehicle = GetVehiclePedIsIn(ped, false)
-    for i=-2,GetVehicleMaxNumberOfPassengers(vehicle) do
-        if(GetPedInVehicleSeat(vehicle, i) == ped) then return i end
+function GetPedVehicleSeat(ped, vehicle)
+    vehicle = vehicle or GetVehiclePedIsIn(ped, false)
+    for i = -1, GetVehicleMaxNumberOfPassengers(vehicle) do
+        if GetPedInVehicleSeat(vehicle, i) == ped then return i end
     end
     return -2
 end

--- a/resources/[system]/runcode/runcode_cl.lua
+++ b/resources/[system]/runcode/runcode_cl.lua
@@ -1,6 +1,4 @@
-RegisterNetEvent('runcode:gotSnippet')
-
-AddEventHandler('runcode:gotSnippet', function(id, lang, code)
+RegisterNetEvent('runcode:gotSnippet', function(id, lang, code)
 	local res, err = RunCode(lang, code)
 
 	if not err then

--- a/resources/[system]/runcode/runcode_ui.lua
+++ b/resources/[system]/runcode/runcode_ui.lua
@@ -1,8 +1,6 @@
 local openData
 
-RegisterNetEvent('runcode:openUi')
-
-AddEventHandler('runcode:openUi', function(options)
+RegisterNetEvent('runcode:openUi', function(options)
     openData = {
         type = 'open',
         options = options,
@@ -48,9 +46,7 @@ RegisterNUICallback('runCodeInBand', function(args, cb)
     TriggerServerEvent('runcode:runInBand', id, args)
 end)
 
-RegisterNetEvent('runcode:inBandResult')
-
-AddEventHandler('runcode:inBandResult', function(id, result)
+RegisterNetEvent('runcode:inBandResult', function(id, result)
     if rcCbs[id] then
         local cb = rcCbs[id]
         rcCbs[id] = nil

--- a/resources/[system]/runcode/runcode_web.lua
+++ b/resources/[system]/runcode/runcode_web.lua
@@ -50,9 +50,7 @@ local function handleRunCode(data, res)
 	end
 end
 
-RegisterNetEvent('runcode:runInBand')
-
-AddEventHandler('runcode:runInBand', function(id, data)
+RegisterNetEvent('runcode:runInBand', function(id, data)
 	local s = source
 	local privs = GetPrivs(s)
 
@@ -113,7 +111,7 @@ end
 CreateThread(function()
 	while true do
 		Wait(1000)
-		
+
 		if attempts > 0 and (GetGameTimer() - lastAttempt) > 5000 then
 			attempts = 0
 			lastAttempt = 0
@@ -155,8 +153,7 @@ CreateThread(function()
 	end
 end)
 
-RegisterNetEvent('runcode:gotResult')
-AddEventHandler('runcode:gotResult', returnCode)
+RegisterNetEvent('runcode:gotResult', returnCode)
 
 SetHttpHandler(function(req, res)
 	local path = req.path

--- a/resources/[test]/example-loadscreen/index.html
+++ b/resources/[test]/example-loadscreen/index.html
@@ -28,6 +28,7 @@ var count = 0;
 var thisCount = 0;
 
 const emoji = {
+    INIT_CORE: [ '🍇' ],
     INIT_BEFORE_MAP_LOADED: [ '🍉' ],
     INIT_AFTER_MAP_LOADED: [ '🍋', '🍊' ],
     INIT_SESSION: [ '🍐', '🍅', '🍆' ],
@@ -38,7 +39,7 @@ const handlers = {
     {
         count = data.count;
 
-        document.querySelector('.letni h3').innerHTML += emoji[data.type][data.order - 1] || '';
+        document.querySelector('.letni h3').innerHTML += (emoji[data.type] || [])[data.order - 1] || '';
     },
 
     initFunctionInvoking(data)


### PR DESCRIPTION
- Updates to fx_version in fxmanifest
- Use new pattern to have the cb for net events directly with RegisterNetEvent
- Removed deprecated mentions of `cfx.re/playerData.v1alpha1`
- Cleanup for old ways to define exports
- Added proper ped model check when adding spawnpoint
- Optimized vehiclechecker and deathevents loops to make them less heavy